### PR TITLE
feat: View task list items

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "mode": "auto",
             "program": "${workspaceFolder}/main.go",
-            "args": ["view", "tasks"]
+            "args": ["view", "tasks", "--due='[start mon; end fri]'"]
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "mode": "auto",
             "program": "${workspaceFolder}/main.go",
-            "args": ["lists"]
+            "args": ["view", "tasks"]
         }
     ]
 }

--- a/api/lists.go
+++ b/api/lists.go
@@ -50,6 +50,7 @@ type todoTaskListListResponse struct {
 }
 
 func (l *TodoTaskListList) GetListId(name string) (string, error) {
+	name = strings.ToLower(name)
 	for _, item := range *l {
 		if strings.ToLower(item.DisplayName) == name {
 			return item.Id, nil

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -25,16 +25,16 @@ import (
 )
 
 type TodoTask struct {
-	Id                   string     `json:"id"`
-	Title                string     `json:"title"`
-	Importance           string     `json:"importance"`
-	IsReminderOn         bool       `json:"isReminderOn"`
-	Status               string     `json:"status"`
+	Id                   string              `json:"id"`
+	Title                string              `json:"title"`
+	Importance           string              `json:"importance"`
+	IsReminderOn         bool                `json:"isReminderOn"`
+	Status               string              `json:"status"`
 	ReminderDateTime     *datetime.GraphTime `json:"reminderDateTime"`
 	DueDateTime          *datetime.GraphTime `json:"dueDateTime"`
 	Completed            *datetime.GraphTime `json:"completedDateTime"`
-	CreatedDateTime      time.Time  `json:"createdDateTime"`
-	LastModifiedDateTime time.Time  `json:"lastModifiedDateTime"`
+	CreatedDateTime      time.Time           `json:"createdDateTime"`
+	LastModifiedDateTime time.Time           `json:"lastModifiedDateTime"`
 }
 
 type TodoTaskList []TodoTask

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -23,16 +23,16 @@ import (
 )
 
 type TodoTask struct {
-	Id                   string           `json:"id"`
-	Title                string           `json:"title"`
-	Importance           string           `json:"importance"`
-	IsReminderOn         bool             `json:"isReminderOn"`
-	Status               string           `json:"status"`
-	ReminderDateTime     DateTimeTimeZone `json:"reminderDateTime"`
-	DueDateTime          DateTimeTimeZone `json:"dueDateTime"`
-	Completed            DateTimeTimeZone `json:"completedDateTime"`
-	CreatedDateTime      time.Time        `json:"createdDateTime"`
-	LastModifiedDateTime time.Time        `json:"lastModifiedDateTime"`
+	Id                   string            `json:"id"`
+	Title                string            `json:"title"`
+	Importance           string            `json:"importance"`
+	IsReminderOn         bool              `json:"isReminderOn"`
+	Status               string            `json:"status"`
+	ReminderDateTime     *DateTimeTimeZone `json:"reminderDateTime"`
+	DueDateTime          *DateTimeTimeZone `json:"dueDateTime"`
+	Completed            *DateTimeTimeZone `json:"completedDateTime"`
+	CreatedDateTime      time.Time         `json:"createdDateTime"`
+	LastModifiedDateTime time.Time         `json:"lastModifiedDateTime"`
 }
 
 type TodoTaskList []TodoTask

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -20,6 +20,8 @@ package api
 import (
 	"fmt"
 	"time"
+
+	"github.com/dalyisaac/mstodo/datetime"
 )
 
 type TodoTask struct {
@@ -28,9 +30,9 @@ type TodoTask struct {
 	Importance           string     `json:"importance"`
 	IsReminderOn         bool       `json:"isReminderOn"`
 	Status               string     `json:"status"`
-	ReminderDateTime     *GraphTime `json:"reminderDateTime"`
-	DueDateTime          *GraphTime `json:"dueDateTime"`
-	Completed            *GraphTime `json:"completedDateTime"`
+	ReminderDateTime     *datetime.GraphTime `json:"reminderDateTime"`
+	DueDateTime          *datetime.GraphTime `json:"dueDateTime"`
+	Completed            *datetime.GraphTime `json:"completedDateTime"`
 	CreatedDateTime      time.Time  `json:"createdDateTime"`
 	LastModifiedDateTime time.Time  `json:"lastModifiedDateTime"`
 }

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -20,21 +20,19 @@ package api
 import (
 	"fmt"
 	"time"
-
-	"github.com/dalyisaac/mstodo/types"
 )
 
 type TodoTask struct {
-	Id                   string                 `json:"id"`
-	Title                string                 `json:"title"`
-	Importance           string                 `json:"importance"`
-	IsReminderOn         bool                   `json:"isReminderOn"`
-	Status               string                 `json:"status"`
-	ReminderDateTime     types.DateTimeTimeZone `json:"reminderDateTime"`
-	DueDateTime          types.DateTimeTimeZone `json:"dueDateTime"`
-	Completed            types.DateTimeTimeZone `json:"completedDateTime"`
-	CreatedDateTime      time.Time              `json:"createdDateTime"`
-	LastModifiedDateTime time.Time              `json:"lastModifiedDateTime"`
+	Id                   string           `json:"id"`
+	Title                string           `json:"title"`
+	Importance           string           `json:"importance"`
+	IsReminderOn         bool             `json:"isReminderOn"`
+	Status               string           `json:"status"`
+	ReminderDateTime     DateTimeTimeZone `json:"reminderDateTime"`
+	DueDateTime          DateTimeTimeZone `json:"dueDateTime"`
+	Completed            DateTimeTimeZone `json:"completedDateTime"`
+	CreatedDateTime      time.Time        `json:"createdDateTime"`
+	LastModifiedDateTime time.Time        `json:"lastModifiedDateTime"`
 }
 
 type TodoTaskList []TodoTask

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -1,0 +1,62 @@
+/*
+Copyright © 2021 Isaac Daly <isaac.daly@outlook.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package api
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/dalyisaac/mstodo/types"
+)
+
+type TodoTask struct {
+	Id                   string                 `json:"id"`
+	Title                string                 `json:"title"`
+	Importance           string                 `json:"importance"`
+	IsReminderOn         bool                   `json:"isReminderOn"`
+	Status               string                 `json:"status"`
+	ReminderDateTime     types.DateTimeTimeZone `json:"reminderDateTime"`
+	DueDateTime          types.DateTimeTimeZone `json:"dueDateTime"`
+	Completed            types.DateTimeTimeZone `json:"completedDateTime"`
+	CreatedDateTime      time.Time              `json:"createdDateTime"`
+	LastModifiedDateTime time.Time              `json:"lastModifiedDateTime"`
+}
+
+type TodoTaskList []TodoTask
+
+type todoTaskListResponse struct {
+	Value TodoTaskList `json:"value"`
+}
+
+func GetTasks(listId string) (*TodoTaskList, error) {
+	// Create request
+	req, err := CreateRequest()
+	if err != nil {
+		return nil, err
+	}
+
+	// Get request
+	url := fmt.Sprintf("/me/todo/lists/%v/tasks", listId)
+	resp, err := req.SetResult(&todoTaskListResponse{}).Get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	tasks := resp.Result().(*todoTaskListResponse).Value
+	return &tasks, nil
+}

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -23,16 +23,16 @@ import (
 )
 
 type TodoTask struct {
-	Id                   string            `json:"id"`
-	Title                string            `json:"title"`
-	Importance           string            `json:"importance"`
-	IsReminderOn         bool              `json:"isReminderOn"`
-	Status               string            `json:"status"`
-	ReminderDateTime     *DateTimeTimeZone `json:"reminderDateTime"`
-	DueDateTime          *DateTimeTimeZone `json:"dueDateTime"`
-	Completed            *DateTimeTimeZone `json:"completedDateTime"`
-	CreatedDateTime      time.Time         `json:"createdDateTime"`
-	LastModifiedDateTime time.Time         `json:"lastModifiedDateTime"`
+	Id                   string     `json:"id"`
+	Title                string     `json:"title"`
+	Importance           string     `json:"importance"`
+	IsReminderOn         bool       `json:"isReminderOn"`
+	Status               string     `json:"status"`
+	ReminderDateTime     *GraphTime `json:"reminderDateTime"`
+	DueDateTime          *GraphTime `json:"dueDateTime"`
+	Completed            *GraphTime `json:"completedDateTime"`
+	CreatedDateTime      time.Time  `json:"createdDateTime"`
+	LastModifiedDateTime time.Time  `json:"lastModifiedDateTime"`
 }
 
 type TodoTaskList []TodoTask

--- a/api/time.go
+++ b/api/time.go
@@ -15,7 +15,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-package types
+package api
 
 import (
 	"fmt"

--- a/api/time.go
+++ b/api/time.go
@@ -60,7 +60,7 @@ type DateTimeTimeZone struct {
 func (dt *DateTimeTimeZone) String() string {
 	t := time.Time(dt.DateTime)
 	l := time.Location(dt.TimeZone)
-	return fmt.Sprintf("%v (%v)", ToRelativeTime(t), l)
+	return fmt.Sprintf("%v (%v)", ToRelativeTime(t), l.String())
 }
 
 func ToRelativeTime(val time.Time) string {

--- a/api/time.go
+++ b/api/time.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/nleeper/goment"
+	"github.com/dustin/go-humanize"
 )
 
 // Custom time unmarshalling
@@ -60,15 +60,5 @@ type DateTimeTimeZone struct {
 func (dt *DateTimeTimeZone) String() string {
 	t := time.Time(dt.DateTime)
 	l := time.Location(dt.TimeZone)
-	return fmt.Sprintf("%v (%v)", ToRelativeTime(t), l.String())
-}
-
-func ToRelativeTime(val time.Time) string {
-	g, err := goment.New(val)
-	if err != nil {
-		fmt.Println(err)
-		return err.Error()
-	}
-
-	return g.Calendar()
+	return fmt.Sprintf("%v (%v)", humanize.Time(t), l.String())
 }

--- a/cmd/lists.go
+++ b/cmd/lists.go
@@ -23,7 +23,6 @@ import (
 	"github.com/dalyisaac/mstodo/api"
 	"github.com/dalyisaac/mstodo/utils"
 	"github.com/jedib0t/go-pretty/v6/table"
-	"github.com/jedib0t/go-pretty/v6/text"
 	"github.com/spf13/cobra"
 )
 
@@ -75,10 +74,10 @@ func createListsCmd() *cobra.Command {
 }
 
 var listsCmdCols = []table.ColumnConfig{
-	{Name: "ID", Align: text.AlignLeft, Transformer: utils.Transformer},
-	{Name: "Name", Align: text.AlignLeft, Transformer: utils.Transformer},
-	{Name: "Owner", Align: text.AlignCenter, Transformer: utils.Transformer},
-	{Name: "Shared", Align: text.AlignCenter, Transformer: utils.Transformer},
+	utils.LeftColumn("ID"),
+	utils.LeftColumn("Name"),
+	utils.CenterColumn("Owner"),
+	utils.CenterColumn("Shared"),
 }
 
 func getListsCmdParams(filterFlag, sortFlag, excludeFlag string, showIdFlag bool) (*listsParams, error) {

--- a/cmd/lists.go
+++ b/cmd/lists.go
@@ -68,10 +68,17 @@ func createListsCmd() *cobra.Command {
 
 	listsCmd.Flags().StringVarP(&filterFlag, "filter", "f", ".", "Filter the lists which contain this regex")
 	listsCmd.Flags().StringVarP(&sortFlag, "sort", "s", "none", "Sort by the name - choices: "+utils.GetSortOptions())
-	listsCmd.Flags().StringVarP(&excludeFlag, "exclude", "x", "", "Exclude columns: "+utils.GetSortOptions())
+	listsCmd.Flags().StringVarP(&excludeFlag, "exclude", "x", "", "Exclude columns")
 	listsCmd.Flags().BoolVarP(&showIdFlag, "id", "i", false, "Show the list IDs")
 
 	return listsCmd
+}
+
+var listsCmdCols = []table.ColumnConfig{
+	{Name: "ID", Align: text.AlignLeft, Transformer: utils.Transformer},
+	{Name: "Name", Align: text.AlignLeft, Transformer: utils.Transformer},
+	{Name: "Owner", Align: text.AlignCenter, Transformer: utils.Transformer},
+	{Name: "Shared", Align: text.AlignCenter, Transformer: utils.Transformer},
 }
 
 func getListsCmdParams(filterFlag, sortFlag, excludeFlag string, showIdFlag bool) (*listsParams, error) {
@@ -87,17 +94,13 @@ func getListsCmdParams(filterFlag, sortFlag, excludeFlag string, showIdFlag bool
 		return nil, err
 	}
 
+	// Show ID flag
 	if !showIdFlag {
 		excludeFlag = "ID," + excludeFlag
 	}
 
 	// Construct excluded columns
-	cols, err := utils.GetAllowedColumns(excludeFlag, []table.ColumnConfig{
-		{Name: "ID", Align: text.AlignLeft, Transformer: utils.Transformer},
-		{Name: "Name", Align: text.AlignLeft, Transformer: utils.Transformer},
-		{Name: "Owner", Align: text.AlignCenter, Transformer: utils.Transformer},
-		{Name: "Shared", Align: text.AlignCenter, Transformer: utils.Transformer},
-	})
+	cols, err := utils.GetAllowedColumns(excludeFlag, listsCmdCols)
 	if err != nil {
 		return nil, err
 	}
@@ -110,20 +113,21 @@ func getListsCmdParams(filterFlag, sortFlag, excludeFlag string, showIdFlag bool
 }
 
 func printTaskListList(taskListList api.TodoTaskListList, params *listsParams) {
-	rows := table.Row{}
+	headerRow := table.Row{}
 	columns := params.columns
 
+	// Add the column names to the header row
 	for _, c := range columns {
-		rows = append(rows, c.Name)
+		headerRow = append(headerRow, c.Name)
 	}
 
-	t := utils.CreateFormattedTable(&rows, &columns)
+	t := utils.CreateFormattedTable(&headerRow, &columns)
 
-	for _, taskItem := range taskListList {
-		if params.filter.MatchString(taskItem.DisplayName) {
+	for _, taskList := range taskListList {
+		if params.filter.MatchString(taskList.DisplayName) {
 			row := table.Row{}
 
-			row = append(row, getAllowedTaskItemFields(taskItem, columns)...)
+			row = append(row, getAllowedTaskListItemFields(taskList, columns)...)
 			t.AppendRow(row)
 		}
 	}
@@ -137,7 +141,7 @@ func printTaskListList(taskListList api.TodoTaskListList, params *listsParams) {
 	t.Render()
 }
 
-func getAllowedTaskItemFields(taskItem api.TodoTaskListItem, columns []table.ColumnConfig) table.Row {
+func getAllowedTaskListItemFields(taskItem api.TodoTaskListItem, columns []table.ColumnConfig) table.Row {
 	fields := table.Row{}
 
 	for _, col := range columns {

--- a/cmd/view.go
+++ b/cmd/view.go
@@ -1,0 +1,198 @@
+/*
+Copyright © 2021 Isaac Daly <isaac.daly@outlook.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package cmd
+
+import (
+	"errors"
+	"regexp"
+
+	"github.com/dalyisaac/mstodo/api"
+	"github.com/dalyisaac/mstodo/utils"
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/jedib0t/go-pretty/v6/text"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+
+	rootCmd.AddCommand(createViewCmd())
+}
+
+type viewParams struct {
+	columns []table.ColumnConfig
+	filter  *regexp.Regexp
+	sort    []table.SortBy
+}
+
+func createViewCmd() *cobra.Command {
+	var (
+		filterFlag, sortFlag, excludeFlag string
+		showIdFlag                        bool
+	)
+
+	// viewCmd represents the view command
+	var viewCmd = &cobra.Command{
+		Use:   "view <list name>",
+		Short: "View a specific list",
+		Long:  `View a specific task list`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return errors.New("missing list name")
+			}
+
+			params, err := getViewCmdParams(filterFlag, sortFlag, excludeFlag, showIdFlag)
+			if err != nil {
+				return err
+			}
+
+			// Get name
+			name, err := utils.CleanName(args[0])
+			if err != nil {
+				return nil
+			}
+
+			// Get lists
+			lists, err := api.GetLists()
+			if err != nil {
+				return err
+			}
+
+			// Get task list id
+			listId, err := lists.GetListId(name)
+			if err != nil {
+				return err
+			}
+
+			// Get task list
+			tasks, err := api.GetTasks(listId)
+			if err != nil {
+				return err
+			}
+
+			// Display results
+			printTaskList(*tasks, params)
+
+			return nil
+		},
+	}
+
+	viewCmd.Flags().StringVarP(&filterFlag, "filter", "f", ".", "Filter the tasks which contain this regex")
+	viewCmd.Flags().StringVarP(&sortFlag, "sort", "s", "none", "Sort by the fields, for example: --sort=[title:dsc,created:asc,status]")
+	viewCmd.Flags().StringVarP(&excludeFlag, "exclude", "x", "", "Exclude columns")
+	viewCmd.Flags().BoolVarP(&showIdFlag, "id", "i", false, "Show the task IDs")
+
+	return viewCmd
+}
+
+var viewCmdCols = []table.ColumnConfig{
+	{Name: "Id", Align: text.AlignLeft, Transformer: utils.Transformer},
+	{Name: "Title", Align: text.AlignLeft, Transformer: utils.Transformer},
+	{Name: "Importance", Align: text.AlignCenter, Transformer: utils.Transformer},
+	{Name: "Status", Align: text.AlignCenter, Transformer: utils.StatusTransformer},
+	{Name: "Reminder", Align: text.AlignCenter, Transformer: utils.Transformer},
+	{Name: "Due Date", Align: text.AlignCenter, Transformer: utils.Transformer},
+	{Name: "Completed", Align: text.AlignCenter, Transformer: utils.Transformer},
+	{Name: "Created", Align: text.AlignCenter, Transformer: utils.Transformer},
+	{Name: "Last Modified", Align: text.AlignCenter, Transformer: utils.Transformer},
+}
+
+func getViewCmdParams(filterFlag, sortFlag, excludeFlag string, showIdFlag bool) (*viewParams, error) {
+	// Validate filter
+	r, err := regexp.Compile(filterFlag)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get sort
+	sortBy, err := utils.GetSortByColumns(sortFlag, viewCmdCols)
+	if err != nil {
+		return nil, err
+	}
+
+	// Show ID flag
+	if !showIdFlag {
+		excludeFlag = "ID," + excludeFlag
+	}
+
+	// Construct excluded columns
+	cols, err := utils.GetAllowedColumns(excludeFlag, viewCmdCols)
+	if err != nil {
+		return nil, err
+	}
+
+	return &viewParams{
+		columns: cols,
+		filter:  r,
+		sort:    sortBy,
+	}, nil
+}
+
+func printTaskList(taskList api.TodoTaskList, params *viewParams) {
+	headerRow := table.Row{}
+	columns := params.columns
+
+	// Add the column names to the header row
+	for _, c := range columns {
+		headerRow = append(headerRow, c.Name)
+	}
+
+	t := utils.CreateFormattedTable(&headerRow, &columns)
+
+	for _, todoTask := range taskList {
+		if params.filter.MatchString(todoTask.Title) {
+			row := table.Row{}
+			row = append(row, getAllowedTodoTaskFields(todoTask, columns)...)
+			t.AppendRow(row)
+		}
+	}
+
+	if len(params.sort) != 0 {
+		t.SortBy(params.sort)
+	}
+
+	t.Render()
+}
+
+func getAllowedTodoTaskFields(todoTask api.TodoTask, columns []table.ColumnConfig) table.Row {
+	fields := table.Row{}
+
+	for _, col := range columns {
+		switch col.Name {
+		case "Id":
+			fields = append(fields, todoTask.Id)
+		case "Title":
+			fields = append(fields, todoTask.Title)
+		case "Importance":
+			fields = append(fields, todoTask.Importance)
+		case "Status":
+			fields = append(fields, todoTask.Status)
+		case "Reminder":
+			fields = append(fields, todoTask.ReminderDateTime)
+		case "Due Date":
+			fields = append(fields, todoTask.DueDateTime)
+		case "Completed":
+			fields = append(fields, todoTask.Completed)
+		case "Created":
+			fields = append(fields, todoTask.CreatedDateTime)
+		case "Last Modified":
+			fields = append(fields, todoTask.LastModifiedDateTime)
+		}
+	}
+
+	return fields
+}

--- a/cmd/view.go
+++ b/cmd/view.go
@@ -90,7 +90,7 @@ func createViewCmd() *cobra.Command {
 	}
 
 	viewCmd.Flags().StringVarP(&filterFlag, "filter", "f", ".", "Filter the tasks which contain this regex")
-	viewCmd.Flags().StringVarP(&sortFlag, "sort", "s", "none", "Sort by the fields, for example: --sort=[title:dsc,created:asc,status]")
+	viewCmd.Flags().StringVarP(&sortFlag, "sort", "s", "none", "Sort by the fields, for example: --sort=\"[title:dsc,created:asc,status]\"")
 	viewCmd.Flags().StringVarP(&excludeFlag, "exclude", "x", "", "Exclude columns")
 	viewCmd.Flags().BoolVarP(&absoluteTime, "absolute", "a", false, "Show absolute datetime")
 	viewCmd.Flags().BoolVarP(&showIdFlag, "id", "i", false, "Show the task IDs")

--- a/cmd/view.go
+++ b/cmd/view.go
@@ -24,12 +24,10 @@ import (
 	"github.com/dalyisaac/mstodo/api"
 	"github.com/dalyisaac/mstodo/utils"
 	"github.com/jedib0t/go-pretty/v6/table"
-	"github.com/jedib0t/go-pretty/v6/text"
 	"github.com/spf13/cobra"
 )
 
 func init() {
-
 	rootCmd.AddCommand(createViewCmd())
 }
 
@@ -100,15 +98,15 @@ func createViewCmd() *cobra.Command {
 }
 
 var viewCmdCols = []table.ColumnConfig{
-	{Name: "Id", Align: text.AlignLeft, Transformer: utils.Transformer},
-	{Name: "Title", Align: text.AlignLeft, Transformer: utils.Transformer},
-	{Name: "Importance", Align: text.AlignCenter, Transformer: utils.Transformer},
-	{Name: "Status", Align: text.AlignCenter, Transformer: utils.StatusTransformer},
-	{Name: "Reminder", Align: text.AlignCenter, Transformer: utils.Transformer},
-	{Name: "Due Date", Align: text.AlignCenter, Transformer: utils.Transformer},
-	{Name: "Completed", Align: text.AlignCenter, Transformer: utils.Transformer},
-	{Name: "Created", Align: text.AlignCenter, Transformer: utils.Transformer},
-	{Name: "Last Modified", Align: text.AlignCenter, Transformer: utils.Transformer},
+	utils.LeftColumn("Id"),
+	utils.LeftColumn("Title"),
+	utils.CenterColumn("Importance"),
+	utils.CenterColumnTransformer("Status", utils.StatusTransformer),
+	utils.CenterColumn("Reminder"),
+	utils.CenterColumn("Due Date"),
+	utils.CenterColumn("Completed"),
+	utils.CenterColumn("Created"),
+	utils.CenterColumn("Last Modified"),
 }
 
 func getViewCmdParams(filterFlag, sortFlag, excludeFlag string, showIdFlag bool) (*viewParams, error) {

--- a/datetime/datefilters.go
+++ b/datetime/datefilters.go
@@ -1,0 +1,51 @@
+/*
+Copyright © 2021 Isaac Daly <isaac.daly@outlook.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package datetime
+
+import "time"
+
+type DateFilters struct {
+	Start *time.Time
+	End   *time.Time
+}
+
+func (filters *DateFilters) Contains(g *GraphTime) bool {
+	if filters == nil {
+		return true
+	}
+
+	if g == nil {
+		return false
+	}
+
+	t := time.Time(*g)
+
+	if filters.Start != nil {
+		if t.Before(*filters.Start) {
+			return false
+		}
+	}
+
+	if filters.End != nil {
+		if t.After(*filters.End) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/datetime/json.go
+++ b/datetime/json.go
@@ -15,7 +15,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-package api
+package datetime
 
 import (
 	"encoding/json"

--- a/datetime/parser.go
+++ b/datetime/parser.go
@@ -32,12 +32,7 @@ var Parser = (&parserWrapper{now: func() time.Time {
 	return time.Date(n.Year(), n.Month(), n.Day(), 0, 0, 0, 0, time.UTC)
 }}).parser
 
-const parserCutset = " "
-
-type DateFilters struct {
-	Start *time.Time
-	End   *time.Time
-}
+const parserCutset = "[] '\""
 
 func (parser *parserWrapper) parser(input string) (*DateFilters, error) {
 	parts := strings.Split(input, ";")

--- a/datetime/parser.go
+++ b/datetime/parser.go
@@ -1,0 +1,246 @@
+/*
+Copyright © 2021 Isaac Daly <isaac.daly@outlook.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package datetime
+
+import (
+	"errors"
+	"strings"
+	"time"
+)
+
+type parserWrapper struct {
+	now func() time.Time
+}
+
+var Parser = (&parserWrapper{now: func() time.Time {
+	n := time.Now()
+	return time.Date(n.Year(), n.Month(), n.Day(), 0, 0, 0, 0, time.UTC)
+}}).parser
+
+const parserCutset = " "
+
+type DateFilters struct {
+	Start *time.Time
+	End   *time.Time
+}
+
+func (parser *parserWrapper) parser(input string) (*DateFilters, error) {
+	parts := strings.Split(input, ";")
+	filters := DateFilters{}
+
+	if len(parts) == 0 {
+		return nil, errors.New("empty filter")
+	}
+
+	if len(parts) > 2 {
+		return nil, errors.New("too many parts")
+	}
+
+	var err error
+	var start, end *time.Time
+	for _, p := range parts {
+		p = strings.Trim(strings.ToLower(p), parserCutset)
+
+		if strings.Contains(p, "start") {
+			start, err = parser.parseDate(p)
+		} else if strings.Contains(p, "end") {
+			end, err = parser.parseDate(p)
+		} else {
+			return nil, errors.New("missing qualifier")
+		}
+
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	filters.Start = start
+	filters.End = end
+	return &filters, nil
+
+}
+
+var dateLayouts = []string{
+	"02/Jan/2006",
+	"02/JAN/2006",
+	"2/Jan/2006",
+	"2/JAN/2006",
+	"02/01/2006",
+	"2/01/2006",
+	"2/01",
+	"02-Jan 2006",
+	"02-Jan",
+	"Jan 02, 2006",
+	"Jan 02",
+	"Jan 2",
+	"January 02, 2006",
+}
+
+func (parser *parserWrapper) parseDate(input string) (*time.Time, error) {
+	for _, layout := range dateLayouts {
+		if date, err := time.Parse(layout, input); err != nil {
+			return parser.fixYear(date), nil
+		}
+	}
+
+	if date, err := parser.parseDay(input); err != nil {
+		return date, nil
+	}
+
+	return nil, errors.New("invalid date")
+}
+
+func (parser *parserWrapper) fixYear(date time.Time) *time.Time {
+	if date.Year() == 0 {
+		date.AddDate(parser.now().Year(), 0, 0)
+	}
+	return &date
+}
+
+type relative int
+
+const (
+	none relative = iota
+	last
+	this
+	next
+)
+
+func (parser *parserWrapper) parseDay(input string) (*time.Time, error) {
+	if len(input) < 3 {
+		return nil, errors.New("day too short")
+	}
+
+	// Get adjective
+	relative := none
+	start := 4
+
+	if len(input) >= 8 {
+		// last, this, next
+		switch input[:4] {
+		case "last":
+			relative = last
+		case "this":
+			relative = this
+		case "next":
+			relative = next
+		default:
+			start = 0
+		}
+	}
+
+	// Get day of week
+	if start >= len(input) {
+		return nil, errors.New("invalid date")
+	}
+
+	day, err := parser.getDayPart(input, start)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get date based on day of week
+	result := parser.getDateFromWeekday(relative, day)
+
+	return &result, nil
+}
+
+func (parser *parserWrapper) getDayPart(input string, start int) (time.Weekday, error) {
+	dayPart := strings.Trim(input[start:], parserCutset)
+	if len(dayPart) < 3 {
+		return -1, errors.New("day is too short")
+	}
+
+	dayPart = input[:3]
+
+	switch dayPart {
+	case "mon":
+		return time.Monday, nil
+	case "tue":
+		return time.Tuesday, nil
+	case "wed":
+		return time.Wednesday, nil
+	case "thu":
+		return time.Thursday, nil
+	case "fri":
+		return time.Friday, nil
+	case "sat":
+		return time.Saturday, nil
+	case "sun":
+		return time.Sunday, nil
+	default:
+		return -1, errors.New("invalid day")
+	}
+}
+
+func (parser *parserWrapper) getDateFromWeekday(relative relative, day time.Weekday) time.Time {
+	var result time.Time
+
+	switch relative {
+	case none:
+		result = parser.getClosestDayInstance(day)
+	case this:
+		result = parser.getClosestDayInstance(day)
+	case last:
+		result = parser.getPreviousDayInstance(day)
+	case next:
+		result = parser.getNextDayInstance(day)
+	}
+
+	return result
+}
+
+func (parser *parserWrapper) getClosestDayInstance(day time.Weekday) time.Time {
+	currentDay := parser.now().Weekday()
+
+	if day <= currentDay {
+		return parser.now().AddDate(0, 0, -int(currentDay-day))
+	}
+	return parser.now().AddDate(0, 0, int(day-currentDay))
+}
+
+func (parser *parserWrapper) getPreviousDayInstance(day time.Weekday) time.Time {
+	currentDay := parser.now().Weekday()
+
+	diff := mod(int(currentDay - day), 7)
+	if diff == 0 {
+		diff = 7
+	}
+
+	return parser.now().AddDate(0, 0, int(-diff))
+}
+
+func (parser *parserWrapper) getNextDayInstance(day time.Weekday) time.Time {
+	currentDay := parser.now().Weekday()
+
+	diff := mod(int(day - currentDay), 7)
+	if diff == 0 {
+		diff = 7
+	}
+
+	return parser.now().AddDate(0, 0, int(diff))
+}
+
+// mod implements Python-like modulo behavior
+func mod(d, m int) int {
+	res := d % m
+	if (res < 0 && m > 0) || (res > 0 && m < 0) {
+		return res + m
+	}
+	return res
+}

--- a/datetime/parser_test.go
+++ b/datetime/parser_test.go
@@ -1,0 +1,571 @@
+/*
+Copyright © 2021 Isaac Daly <isaac.daly@outlook.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package datetime
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func Test_parserWrapper_parser(t *testing.T) {
+	type fields struct {
+		now func() time.Time
+	}
+	type args struct {
+		input string
+	}
+
+	testFields := fields{now: func() time.Time {
+		// Today is Wednesday
+		return date(7, 7)
+	}}
+
+	filterP := func(f DateFilters) *DateFilters {
+		return &f
+	}
+
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *DateFilters
+		wantErr bool
+	}{
+		{name: "start end", fields: testFields, wantErr: false, args: args{input: "start Monday; end Friday"}, want: filterP(DateFilters{Start: p(date(5, 7)), End: p(date(9, 7))})},
+		{name: "end start", fields: testFields, wantErr: false, args: args{input: "end Friday; start Monday"}, want: filterP(DateFilters{Start: p(date(5, 7)), End: p(date(9, 7))})},
+		{name: "only start", fields: testFields, wantErr: false, args: args{input: "start Monday"}, want: filterP(DateFilters{Start: p(date(5, 7))})},
+		{name: "only end", fields: testFields, wantErr: false, args: args{input: "end Friday"}, want: filterP(DateFilters{End: p(date(9, 7))})},
+		{name: "no qualifier", fields: testFields, wantErr: true, args: args{input: "monday"}, want: nil},
+		{name: "force error", fields: testFields, wantErr: true, args: args{input: "start garbage"}, want: nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := &parserWrapper{
+				now: tt.fields.now,
+			}
+			got, err := parser.parser(tt.args.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parserWrapper.parser() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parserWrapper.parser() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_contains(t *testing.T) {
+	type args struct {
+		s         string
+		substring string
+	}
+	tests := []struct {
+		name string
+		args args
+		want int
+	}{
+		{name: "'start mon' contains 'start'", args: args{s: "start mon", substring: "start"}, want: 5 },
+		{name: "'start mon' contains 'end'", args: args{s: "start mon", substring: "end"}, want: -1 },
+		{name: "too short", args: args{s: "end", substring: "start"}, want: -1 },
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := contains(tt.args.s, tt.args.substring); got != tt.want {
+				t.Errorf("contains() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_parserWrapper_parseDate(t *testing.T) {
+	type fields struct {
+		now func() time.Time
+	}
+	type args struct {
+		input string
+	}
+
+	testFields := fields{now: func() time.Time {
+		// Today is Wednesday
+		return date(7, 7)
+	}}
+
+	wantDate := p(time.Date(2021, time.January, 2, 0, 0, 0, 0, time.UTC))
+
+	tests := []struct {
+		fields  fields
+		args    args
+		want    *time.Time
+		wantErr bool
+	}{
+		{args: args{"02/Jan/2021"}, fields: testFields, want: wantDate, wantErr: false},
+		{args: args{"02/JAN/2021"}, fields: testFields, want: wantDate, wantErr: false},
+		{args: args{"02-Jan-2021"}, fields: testFields, want: wantDate, wantErr: false},
+		{args: args{"02-JAN-2021"}, fields: testFields, want: wantDate, wantErr: false},
+		{args: args{"02-Jan-21"}, fields: testFields, want: wantDate, wantErr: false},
+		{args: args{"02-JAN-21"}, fields: testFields, want: wantDate, wantErr: false},
+		{args: args{"2/Jan/2021"}, fields: testFields, want: wantDate, wantErr: false},
+		{args: args{"2/JAN/2021"}, fields: testFields, want: wantDate, wantErr: false},
+		{args: args{"02/01/2021"}, fields: testFields, want: wantDate, wantErr: false},
+		{args: args{"2/01/2021"}, fields: testFields, want: wantDate, wantErr: false},
+		{args: args{"2/01"}, fields: testFields, want: wantDate, wantErr: false},
+		{args: args{"02-Jan 2021"}, fields: testFields, want: wantDate, wantErr: false},
+		{args: args{"02-Jan"}, fields: testFields, want: wantDate, wantErr: false},
+		{args: args{"Jan 02, 2021"}, fields: testFields, want: wantDate, wantErr: false},
+		{args: args{"Jan 02"}, fields: testFields, want: wantDate, wantErr: false},
+		{args: args{"Jan 2"}, fields: testFields, want: wantDate, wantErr: false},
+		{args: args{"January 02, 2021"}, fields: testFields, want: wantDate, wantErr: false},
+		{args: args{"last Mon"}, fields: testFields, want: p(date(5, 7)), wantErr: false},
+		{args: args{"Monday"}, fields: testFields, want: p(date(5, 7)), wantErr: false},
+		{args: args{"garbage"}, fields: testFields, want: nil, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.args.input, func(t *testing.T) {
+			parser := &parserWrapper{
+				now: tt.fields.now,
+			}
+			got, err := parser.parseDate(tt.args.input, 0)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parserWrapper.parseDate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parserWrapper.parseDate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_parserWrapper_fixYear(t *testing.T) {
+	type fields struct {
+		now func() time.Time
+	}
+	type args struct {
+		date time.Time
+	}
+
+	testFields := fields{now: func() time.Time {
+		// Today is Wednesday
+		return date(7, 7)
+	}}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   *time.Time
+	}{
+		{name: "0 year", fields: testFields, args: args{date: time.Date(0, 7, 7, 0, 0, 0, 0, time.UTC)}, want: p(time.Date(2021, 7, 7, 0, 0, 0, 0, time.UTC))},
+		{name: "2021 year", fields: testFields, args: args{date: time.Date(2021, 7, 7, 0, 0, 0, 0, time.UTC)}, want: p(time.Date(2021, 7, 7, 0, 0, 0, 0, time.UTC))},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := &parserWrapper{
+				now: tt.fields.now,
+			}
+			if got := parser.fixYear(tt.args.date); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parserWrapper.fixYear() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_parserWrapper_parseDay(t *testing.T) {
+	type fields struct {
+		now func() time.Time
+	}
+	type args struct {
+		input string
+	}
+
+	testFields := fields{now: func() time.Time {
+		// Today is Wednesday
+		return date(7, 7)
+	}}
+
+	tests := []struct {
+		fields  fields
+		args    args
+		want    *time.Time
+		wantErr bool
+	}{
+		// failures
+		{fields: testFields, args: args{input: "mo"}, want: nil, wantErr: true},
+		{fields: testFields, args: args{input: "day"}, want: nil, wantErr: true},
+		{fields: testFields, args: args{input: "last"}, want: nil, wantErr: true},
+
+		// no relative specifier
+		{fields: testFields, args: args{input: "Monday"}, wantErr: false, want: p(date(5, 7))},
+		{fields: testFields, args: args{input: "mon"}, wantErr: false, want: p(date(5, 7))},
+		{fields: testFields, args: args{input: "Tuesday"}, wantErr: false, want: p(date(6, 7))},
+		{fields: testFields, args: args{input: "tue"}, wantErr: false, want: p(date(6, 7))},
+		{fields: testFields, args: args{input: "Wednesday"}, wantErr: false, want: p(date(7, 7))},
+		{fields: testFields, args: args{input: "wed"}, wantErr: false, want: p(date(7, 7))},
+		{fields: testFields, args: args{input: "Thursday"}, wantErr: false, want: p(date(8, 7))},
+		{fields: testFields, args: args{input: "thu"}, wantErr: false, want: p(date(8, 7))},
+		{fields: testFields, args: args{input: "Friday"}, wantErr: false, want: p(date(9, 7))},
+		{fields: testFields, args: args{input: "fri"}, wantErr: false, want: p(date(9, 7))},
+		{fields: testFields, args: args{input: "Saturday"}, wantErr: false, want: p(date(10, 7))},
+		{fields: testFields, args: args{input: "sat"}, wantErr: false, want: p(date(10, 7))},
+		{fields: testFields, args: args{input: "Sunday"}, wantErr: false, want: p(date(4, 7))},
+		{fields: testFields, args: args{input: "sun"}, wantErr: false, want: p(date(4, 7))},
+
+		// this relative specifier
+		{fields: testFields, args: args{input: "this Monday"}, wantErr: false, want: p(date(12, 7))},
+		{fields: testFields, args: args{input: "this mon"}, wantErr: false, want: p(date(12, 7))},
+		{fields: testFields, args: args{input: "this Tuesday"}, wantErr: false, want: p(date(13, 7))},
+		{fields: testFields, args: args{input: "this tue"}, wantErr: false, want: p(date(13, 7))},
+		{fields: testFields, args: args{input: "this Wednesday"}, wantErr: false, want: p(date(7, 7))},
+		{fields: testFields, args: args{input: "this wed"}, wantErr: false, want: p(date(7, 7))},
+		{fields: testFields, args: args{input: "this Thursday"}, wantErr: false, want: p(date(8, 7))},
+		{fields: testFields, args: args{input: "this thu"}, wantErr: false, want: p(date(8, 7))},
+		{fields: testFields, args: args{input: "this Friday"}, wantErr: false, want: p(date(9, 7))},
+		{fields: testFields, args: args{input: "this fri"}, wantErr: false, want: p(date(9, 7))},
+		{fields: testFields, args: args{input: "this Saturday"}, wantErr: false, want: p(date(10, 7))},
+		{fields: testFields, args: args{input: "this sat"}, wantErr: false, want: p(date(10, 7))},
+		{fields: testFields, args: args{input: "this Sunday"}, wantErr: false, want: p(date(11, 7))},
+		{fields: testFields, args: args{input: "this sun"}, wantErr: false, want: p(date(11, 7))},
+
+		// last relative specifier
+		{fields: testFields, args: args{input: "last Monday"}, wantErr: false, want: p(date(5, 7))},
+		{fields: testFields, args: args{input: "last mon"}, wantErr: false, want: p(date(5, 7))},
+		{fields: testFields, args: args{input: "last Tuesday"}, wantErr: false, want: p(date(6, 7))},
+		{fields: testFields, args: args{input: "last tue"}, wantErr: false, want: p(date(6, 7))},
+		{fields: testFields, args: args{input: "last Wednesday"}, wantErr: false, want: p(date(30, 6))},
+		{fields: testFields, args: args{input: "last wed"}, wantErr: false, want: p(date(30, 6))},
+		{fields: testFields, args: args{input: "last Thursday"}, wantErr: false, want: p(date(1, 7))},
+		{fields: testFields, args: args{input: "last thu"}, wantErr: false, want: p(date(1, 7))},
+		{fields: testFields, args: args{input: "last Friday"}, wantErr: false, want: p(date(2, 7))},
+		{fields: testFields, args: args{input: "last fri"}, wantErr: false, want: p(date(2, 7))},
+		{fields: testFields, args: args{input: "last Saturday"}, wantErr: false, want: p(date(3, 7))},
+		{fields: testFields, args: args{input: "last sat"}, wantErr: false, want: p(date(3, 7))},
+		{fields: testFields, args: args{input: "last Sunday"}, wantErr: false, want: p(date(4, 7))},
+		{fields: testFields, args: args{input: "last sun"}, wantErr: false, want: p(date(4, 7))},
+
+		// next relative specifier
+		{fields: testFields, args: args{input: "next Monday"}, wantErr: false, want: p(date(12, 7))},
+		{fields: testFields, args: args{input: "next mon"}, wantErr: false, want: p(date(12, 7))},
+		{fields: testFields, args: args{input: "next Tuesday"}, wantErr: false, want: p(date(13, 7))},
+		{fields: testFields, args: args{input: "next tue"}, wantErr: false, want: p(date(13, 7))},
+		{fields: testFields, args: args{input: "next Wednesday"}, wantErr: false, want: p(date(14, 7))},
+		{fields: testFields, args: args{input: "next wed"}, wantErr: false, want: p(date(14, 7))},
+		{fields: testFields, args: args{input: "next Thursday"}, wantErr: false, want: p(date(15, 7))},
+		{fields: testFields, args: args{input: "next thu"}, wantErr: false, want: p(date(15, 7))},
+		{fields: testFields, args: args{input: "next Friday"}, wantErr: false, want: p(date(16, 7))},
+		{fields: testFields, args: args{input: "next fri"}, wantErr: false, want: p(date(16, 7))},
+		{fields: testFields, args: args{input: "next Saturday"}, wantErr: false, want: p(date(17, 7))},
+		{fields: testFields, args: args{input: "next sat"}, wantErr: false, want: p(date(17, 7))},
+		{fields: testFields, args: args{input: "next Sunday"}, wantErr: false, want: p(date(18, 7))},
+		{fields: testFields, args: args{input: "next sun"}, wantErr: false, want: p(date(18, 7))},
+	}
+	for _, tt := range tests {
+		t.Run(tt.args.input, func(t *testing.T) {
+			parser := &parserWrapper{
+				now: tt.fields.now,
+			}
+			got, err := parser.parseDay(tt.args.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parserWrapper.parseDay() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parserWrapper.parseDay() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_parserWrapper_getDayPart(t *testing.T) {
+	type fields struct {
+		now func() time.Time
+	}
+	type args struct {
+		input string
+		start int
+	}
+
+	testFields := fields{now: func() time.Time {
+		// Today is Wednesday
+		return date(7, 7)
+	}}
+
+	tests := []struct {
+		fields  fields
+		args    args
+		want    time.Weekday
+		wantErr bool
+	}{
+		{fields: testFields, args: args{input: "mo", start: 0}, want: -1, wantErr: true},
+		{fields: testFields, args: args{input: "day", start: 0}, want: -1, wantErr: true},
+		{fields: testFields, args: args{input: "Monday", start: 0}, want: time.Monday, wantErr: false},
+		{fields: testFields, args: args{input: "Tuesday", start: 0}, want: time.Tuesday, wantErr: false},
+		{fields: testFields, args: args{input: "Wednesday", start: 0}, want: time.Wednesday, wantErr: false},
+		{fields: testFields, args: args{input: "Thursday", start: 0}, want: time.Thursday, wantErr: false},
+		{fields: testFields, args: args{input: "Friday", start: 0}, want: time.Friday, wantErr: false},
+		{fields: testFields, args: args{input: "Saturday", start: 0}, want: time.Saturday, wantErr: false},
+		{fields: testFields, args: args{input: "Sunday", start: 0}, want: time.Sunday, wantErr: false},
+		{fields: testFields, args: args{input: "mon", start: 0}, want: time.Monday, wantErr: false},
+		{fields: testFields, args: args{input: "tue", start: 0}, want: time.Tuesday, wantErr: false},
+		{fields: testFields, args: args{input: "wed", start: 0}, want: time.Wednesday, wantErr: false},
+		{fields: testFields, args: args{input: "thu", start: 0}, want: time.Thursday, wantErr: false},
+		{fields: testFields, args: args{input: "fri", start: 0}, want: time.Friday, wantErr: false},
+		{fields: testFields, args: args{input: "sat", start: 0}, want: time.Saturday, wantErr: false},
+		{fields: testFields, args: args{input: "sun", start: 0}, want: time.Sunday, wantErr: false},
+		{fields: testFields, args: args{input: "the date is mon", start: 12}, want: time.Monday, wantErr: false},
+		{fields: testFields, args: args{input: "the date is tue", start: 12}, want: time.Tuesday, wantErr: false},
+		{fields: testFields, args: args{input: "the date is wed", start: 12}, want: time.Wednesday, wantErr: false},
+		{fields: testFields, args: args{input: "the date is thu", start: 12}, want: time.Thursday, wantErr: false},
+		{fields: testFields, args: args{input: "the date is fri", start: 12}, want: time.Friday, wantErr: false},
+		{fields: testFields, args: args{input: "the date is sat", start: 12}, want: time.Saturday, wantErr: false},
+		{fields: testFields, args: args{input: "the date is sun", start: 12}, want: time.Sunday, wantErr: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.args.input, func(t *testing.T) {
+			parser := &parserWrapper{
+				now: tt.fields.now,
+			}
+			got, err := parser.getDayPart(tt.args.input, tt.args.start)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parserWrapper.getDayPart() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("parserWrapper.getDayPart() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_parserWrapper_getDateFromWeekday(t *testing.T) {
+	type fields struct {
+		now func() time.Time
+	}
+	type args struct {
+		relative relative
+		day      time.Weekday
+	}
+
+	testFields := fields{now: func() time.Time {
+		// Today is Wednesday
+		return date(7, 7)
+	}}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   time.Time
+	}{
+		{name: "none wednesday", fields: testFields, args: args{relative: none, day: time.Wednesday}, want: date(7, 7)},
+		{name: "this wednesday", fields: testFields, args: args{relative: this, day: time.Wednesday}, want: date(7, 7)},
+		{name: "this friday", fields: testFields, args: args{relative: this, day: time.Friday}, want: date(9, 7)},
+		{name: "next friday", fields: testFields, args: args{relative: next, day: time.Friday}, want: date(16, 7)},
+		{name: "last friday", fields: testFields, args: args{relative: last, day: time.Friday}, want: date(2, 7)},
+		{name: "last tuesday", fields: testFields, args: args{relative: last, day: time.Tuesday}, want: date(6, 7)},
+		{name: "next tuesday", fields: testFields, args: args{relative: next, day: time.Tuesday}, want: date(13, 7)},
+		{name: "next thursday", fields: testFields, args: args{relative: next, day: time.Thursday}, want: date(15, 7)},
+		{name: "this thursday", fields: testFields, args: args{relative: this, day: time.Thursday}, want: date(8, 7)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := &parserWrapper{
+				now: tt.fields.now,
+			}
+			if got := parser.getDateFromWeekday(tt.args.relative, tt.args.day); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parserWrapper.getDateFromWeekday() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_parserWrapper_getClosestDayInstance(t *testing.T) {
+	type fields struct {
+		now func() time.Time
+	}
+	type args struct {
+		day time.Weekday
+	}
+
+	testFields := fields{now: func() time.Time {
+		// Today is Wednesday
+		return date(7, 7)
+	}}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   time.Time
+	}{
+		{name: "tuesday", fields: testFields, args: args{day: time.Tuesday}, want: date(6, 7)},
+		{name: "wednesday", fields: testFields, args: args{day: time.Wednesday}, want: date(7, 7)},
+		{name: "friday", fields: testFields, args: args{day: time.Friday}, want: date(9, 7)},
+		{name: "saturday", fields: testFields, args: args{day: time.Saturday}, want: date(10, 7)},
+		{name: "sunday", fields: testFields, args: args{day: time.Sunday}, want: date(4, 7)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := &parserWrapper{
+				now: tt.fields.now,
+			}
+			if got := parser.getClosestDayInstance(tt.args.day); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parserWrapper.getClosestDayInstance() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_parserWrapper_getThisDayInstance(t *testing.T) {
+	type fields struct {
+		now func() time.Time
+	}
+	type args struct {
+		day time.Weekday
+	}
+
+	testFields := fields{now: func() time.Time {
+		// Today is Wednesday
+		return date(7, 7)
+	}}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   time.Time
+	}{
+		{name: "this Friday", fields: testFields, args: args{day: time.Friday}, want: date(9, 7)},
+		{name: "this Tuesday", fields: testFields, args: args{day: time.Tuesday}, want: date(13, 7)},
+		{name: "this Wednesday", fields: testFields, args: args{day: time.Wednesday}, want: date(7, 7)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := &parserWrapper{
+				now: tt.fields.now,
+			}
+			if got := parser.getThisDayInstance(tt.args.day); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parserWrapper.getPreviousDayInstance() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_parserWrapper_getLastDayInstance(t *testing.T) {
+	type fields struct {
+		now func() time.Time
+	}
+	type args struct {
+		day time.Weekday
+	}
+
+	testFields := fields{now: func() time.Time {
+		// Today is Wednesday
+		return date(7, 7)
+	}}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   time.Time
+	}{
+		{name: "last Friday", fields: testFields, args: args{day: time.Friday}, want: date(2, 7)},
+		{name: "last Tuesday", fields: testFields, args: args{day: time.Tuesday}, want: date(6, 7)},
+		{name: "last Wednesday", fields: testFields, args: args{day: time.Wednesday}, want: date(30, 6)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := &parserWrapper{
+				now: tt.fields.now,
+			}
+			if got := parser.getLastDayInstance(tt.args.day); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parserWrapper.getPreviousDayInstance() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_parserWrapper_getNextDayInstance(t *testing.T) {
+	type fields struct {
+		now func() time.Time
+	}
+	type args struct {
+		day time.Weekday
+	}
+
+	testFields := fields{now: func() time.Time {
+		// Today is Wednesday
+		return date(7, 7)
+	}}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   time.Time
+	}{
+		{name: "next Friday", fields: testFields, args: args{day: time.Friday}, want: date(16, 7)},
+		{name: "next Tuesday", fields: testFields, args: args{day: time.Tuesday}, want: date(13, 7)},
+		{name: "next Wednesday", fields: testFields, args: args{day: time.Wednesday}, want: date(14, 7)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := &parserWrapper{
+				now: tt.fields.now,
+			}
+			if got := parser.getNextDayInstance(tt.args.day); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parserWrapper.getNextDayInstance() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// p takes a `Time` instance and returns its pointer
+func p(t time.Time) *time.Time {
+	return &t
+}
+
+func date(day int, month time.Month) time.Time {
+	return time.Date(2021, month, day, 0, 0, 0, 0, time.UTC)
+}
+
+
+func Test_mod(t *testing.T) {
+	type args struct {
+		d int
+		m int
+	}
+	tests := []struct {
+		name string
+		args args
+		want int
+	}{
+		{name: "4 % 7", args: args{d: 4, m: 7}, want: 4},
+		{name: "4 % 7", args: args{d: 4, m: 7}, want: 4},
+		{name: "-3 % 7", args: args{d: -3, m: 7}, want: 4},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mod(tt.args.d, tt.args.m); got != tt.want {
+				t.Errorf("mod() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/datetime/parser_test.go
+++ b/datetime/parser_test.go
@@ -81,9 +81,9 @@ func Test_contains(t *testing.T) {
 		args args
 		want int
 	}{
-		{name: "'start mon' contains 'start'", args: args{s: "start mon", substring: "start"}, want: 5 },
-		{name: "'start mon' contains 'end'", args: args{s: "start mon", substring: "end"}, want: -1 },
-		{name: "too short", args: args{s: "end", substring: "start"}, want: -1 },
+		{name: "'start mon' contains 'start'", args: args{s: "start mon", substring: "start"}, want: 5},
+		{name: "'start mon' contains 'end'", args: args{s: "start mon", substring: "end"}, want: -1},
+		{name: "too short", args: args{s: "end", substring: "start"}, want: -1},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -545,7 +545,6 @@ func p(t time.Time) *time.Time {
 func date(day int, month time.Month) time.Time {
 	return time.Date(2021, month, day, 0, 0, 0, 0, time.UTC)
 }
-
 
 func Test_mod(t *testing.T) {
 	type args struct {

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,12 @@ module github.com/dalyisaac/mstodo
 go 1.16
 
 require (
+	github.com/dustin/go-humanize v1.0.0
 	github.com/fatih/color v1.12.0
 	github.com/go-resty/resty/v2 v2.6.0
 	github.com/iancoleman/strcase v0.1.3
 	github.com/jedib0t/go-pretty/v6 v6.2.2
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/nleeper/goment v1.4.2
 	github.com/nmrshll/rndm-go v0.0.0-20170430161430-8da3024e53de
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/spf13/cobra v1.1.3

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,10 @@ go 1.16
 require (
 	github.com/fatih/color v1.12.0
 	github.com/go-resty/resty/v2 v2.6.0
+	github.com/iancoleman/strcase v0.1.3
 	github.com/jedib0t/go-pretty/v6 v6.2.2
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/nleeper/goment v1.4.2
 	github.com/nmrshll/rndm-go v0.0.0-20170430161430-8da3024e53de
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/spf13/cobra v1.1.3

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/Xuanwo/go-locale v1.0.0 h1:oqC32Kyiu2XZq+fxtwEg0mWiv9WyDhyHu+sT5cDkgME=
+github.com/Xuanwo/go-locale v1.0.0/go.mod h1:kB9tcLfr4Sp+ByIE9SE7vbUkXkGQqel2XH3EHpL0haA=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
@@ -131,6 +133,8 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/golang/protobuf v1.5.1/go.mod h1:DopwsBzvsk0Fs44TXzsVbJyPhcCPeIwnvohx4u74HPM=
 github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
+github.com/goodsign/monday v1.0.0 h1:Yyk/s/WgudMbAJN6UWSU5xAs8jtNewfqtVblAlw0yoc=
+github.com/goodsign/monday v1.0.0/go.mod h1:r4T4breXpoFwspQNM+u2sLxJb2zyTaxVGqUfTBjWOu8=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
@@ -191,6 +195,8 @@ github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
+github.com/iancoleman/strcase v0.1.3 h1:dJBk1m2/qjL1twPLf68JND55vvivMupZ4wIzE8CTdBw=
+github.com/iancoleman/strcase v0.1.3/go.mod h1:SK73tn/9oHe+/Y0h39VT4UCxmurVJkR5NA7kMEAOgSE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
@@ -245,6 +251,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/nleeper/goment v1.4.2 h1:r4c8KkCrsBJUnVi/IJ5HEqev5QY8aCWOXQtu+eYXtnI=
+github.com/nleeper/goment v1.4.2/go.mod h1:zDl5bAyDhqxwQKAvkSXMRLOdCowrdZz53ofRJc4VhTo=
 github.com/nmrshll/rndm-go v0.0.0-20170430161430-8da3024e53de h1:j+mSQhCm1H2d7apFbM5ODqrTultUvF3jt//DcRNkxVM=
 github.com/nmrshll/rndm-go v0.0.0-20170430161430-8da3024e53de/go.mod h1:OeEnWnbCrUWnPl1xSCGM5/qtWqZ4L15KOAjR/wmxhXc=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
@@ -313,6 +321,8 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+github.com/tkuchiki/go-timezone v0.2.0 h1:yyZVHtQRVZ+wvlte5HXvSpBkR0dPYnPEIgq9qqAqltk=
+github.com/tkuchiki/go-timezone v0.2.0/go.mod h1:b1Ean9v2UXtxSq4TZF0i/TU9NuoWa9hOzOKoGCV2zqY=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -476,6 +486,7 @@ golang.org/x/sys v0.0.0-20200501052902-10377860bb8e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200511232937-7e40ca221e25/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200802091954-4b90ce9b60b3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,6 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
-github.com/Xuanwo/go-locale v1.0.0 h1:oqC32Kyiu2XZq+fxtwEg0mWiv9WyDhyHu+sT5cDkgME=
-github.com/Xuanwo/go-locale v1.0.0/go.mod h1:kB9tcLfr4Sp+ByIE9SE7vbUkXkGQqel2XH3EHpL0haA=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
@@ -74,6 +72,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
+github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -133,8 +133,6 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/golang/protobuf v1.5.1/go.mod h1:DopwsBzvsk0Fs44TXzsVbJyPhcCPeIwnvohx4u74HPM=
 github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
-github.com/goodsign/monday v1.0.0 h1:Yyk/s/WgudMbAJN6UWSU5xAs8jtNewfqtVblAlw0yoc=
-github.com/goodsign/monday v1.0.0/go.mod h1:r4T4breXpoFwspQNM+u2sLxJb2zyTaxVGqUfTBjWOu8=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
@@ -147,6 +145,7 @@ github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
@@ -251,8 +250,6 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/nleeper/goment v1.4.2 h1:r4c8KkCrsBJUnVi/IJ5HEqev5QY8aCWOXQtu+eYXtnI=
-github.com/nleeper/goment v1.4.2/go.mod h1:zDl5bAyDhqxwQKAvkSXMRLOdCowrdZz53ofRJc4VhTo=
 github.com/nmrshll/rndm-go v0.0.0-20170430161430-8da3024e53de h1:j+mSQhCm1H2d7apFbM5ODqrTultUvF3jt//DcRNkxVM=
 github.com/nmrshll/rndm-go v0.0.0-20170430161430-8da3024e53de/go.mod h1:OeEnWnbCrUWnPl1xSCGM5/qtWqZ4L15KOAjR/wmxhXc=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
@@ -321,8 +318,6 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
-github.com/tkuchiki/go-timezone v0.2.0 h1:yyZVHtQRVZ+wvlte5HXvSpBkR0dPYnPEIgq9qqAqltk=
-github.com/tkuchiki/go-timezone v0.2.0/go.mod h1:b1Ean9v2UXtxSq4TZF0i/TU9NuoWa9hOzOKoGCV2zqY=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -486,7 +481,6 @@ golang.org/x/sys v0.0.0-20200501052902-10377860bb8e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200511232937-7e40ca221e25/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200802091954-4b90ce9b60b3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -569,6 +563,7 @@ golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=

--- a/types/time.go
+++ b/types/time.go
@@ -1,0 +1,74 @@
+/*
+Copyright © 2021 Isaac Daly <isaac.daly@outlook.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package types
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/nleeper/goment"
+)
+
+// Custom time unmarshalling
+
+type msgraphTime time.Time
+
+const msgraphTimeLayout = "2006-01-02T15:04:05.0000000"
+
+// UnmarshalJSON parses the json string into the Microsoft Graph time format,
+// as per https://docs.microsoft.com/en-us/graph/api/resources/datetimetimezone?view=graph-rest-1.0
+func (ct *msgraphTime) UnmarshalJSON(b []byte) (err error) {
+	s := strings.Trim(string(b), `"`)
+	nt, err := time.Parse(msgraphTimeLayout, s)
+	*ct = msgraphTime(nt)
+	return err
+}
+
+// Custom location time unmarshalling
+
+type msgraphLocation time.Location
+
+func (ct *msgraphLocation) UnmarshalJSON(b []byte) (err error) {
+	s := strings.Trim(string(b), `"`)
+	loc, err := time.LoadLocation(s)
+	*ct = msgraphLocation(*loc)
+	return err
+}
+
+// DateTimeTimeZone based on https://docs.microsoft.com/en-us/graph/api/resources/datetimetimezone?view=graph-rest-1.0
+type DateTimeTimeZone struct {
+	DateTime msgraphTime     `json:"dateTime"`
+	TimeZone msgraphLocation `json:"timeZone"`
+}
+
+func (dt *DateTimeTimeZone) String() string {
+	t := time.Time(dt.DateTime)
+	l := time.Location(dt.TimeZone)
+	return fmt.Sprintf("%v (%v)", ToRelativeTime(t), l)
+}
+
+func ToRelativeTime(val time.Time) string {
+	g, err := goment.New(val)
+	if err != nil {
+		fmt.Println(err)
+		return err.Error()
+	}
+
+	return g.Calendar()
+}

--- a/utils/clean_name.go
+++ b/utils/clean_name.go
@@ -18,18 +18,16 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package utils
 
 import (
+	"errors"
 	"strings"
 )
 
-// Checks to see if the items array contains the target string.
-// During comparison, each item and the target are compared with lowercase.
-func ContainsString(items []string, target string) bool {
-	target = strings.ToLower(target)
+func CleanName(name string) (string, error) {
+	name = strings.Trim(name, " ")
 
-	for _, v := range items {
-		if strings.ToLower(v) == target {
-			return true
-		}
+	if name == "" {
+		return name, errors.New("name was empty")
 	}
-	return false
+
+	return strings.ToLower(name), nil
 }

--- a/utils/sort.go
+++ b/utils/sort.go
@@ -82,3 +82,46 @@ func getSortMode(flag string, numericSort bool) (table.SortMode, error) {
 
 	return -1, errors.New("invalid sort option - valid options: " + options)
 }
+
+const sortByCutset = "[] "
+
+// GetSortByColumns parses the flags which indicate the columns to sort by
+func GetSortByColumns(s string, columns []table.ColumnConfig) ([]table.SortBy, error) {
+	sortBy := []table.SortBy{}
+
+	s = strings.Trim(s, sortByCutset)
+
+	// Get columns
+	cols := strings.Split(s, ",")
+
+	// Get sorted columns
+	for _, c := range cols {
+		c = strings.Trim(c, sortByCutset)
+
+		// Get parts
+		parts := strings.Split(c, ":")
+
+		if len(parts) == 0 {
+			continue
+		}
+
+		name := strings.Title(parts[0])
+		if !columnsContainName(columns, name) {
+			continue
+		}
+
+		sortMode := table.Asc
+
+		if len(parts) >= 2 {
+			specifiedMode, err := GetSortMode(parts[1])
+			if err != nil {
+				return nil, err
+			}
+			sortMode = specifiedMode
+		}
+
+		sortBy = append(sortBy, table.SortBy{Name: name, Mode: sortMode})
+	}
+
+	return sortBy, nil
+}

--- a/utils/sort.go
+++ b/utils/sort.go
@@ -83,7 +83,7 @@ func getSortMode(flag string, numericSort bool) (table.SortMode, error) {
 	return -1, errors.New("invalid sort option - valid options: " + options)
 }
 
-const sortByCutset = "[] "
+const sortByCutset = "[] \"'"
 
 // GetSortByColumns parses the flags which indicate the columns to sort by
 func GetSortByColumns(s string, columns []table.ColumnConfig) ([]table.SortBy, error) {

--- a/utils/table.go
+++ b/utils/table.go
@@ -21,6 +21,7 @@ import (
 	"os"
 
 	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/jedib0t/go-pretty/v6/text"
 	"github.com/spf13/viper"
 )
 
@@ -95,5 +96,22 @@ func matchTableStyle(style string) *table.Style {
 		return &table.StyleRounded
 	default:
 		return nil
+	}
+}
+
+func LeftColumn(name string) table.ColumnConfig {
+	return table.ColumnConfig{Name: name, Transformer: Transformer}
+}
+
+func CenterColumn(name string) table.ColumnConfig {
+	return CenterColumnTransformer(name, Transformer)
+}
+
+func CenterColumnTransformer(name string, transformer text.Transformer) table.ColumnConfig {
+	return table.ColumnConfig{
+		Name:        name,
+		Align:       text.AlignCenter,
+		AlignHeader: text.AlignCenter,
+		Transformer: transformer,
 	}
 }

--- a/utils/transformers.go
+++ b/utils/transformers.go
@@ -20,7 +20,7 @@ package utils
 import (
 	"time"
 
-	"github.com/dalyisaac/mstodo/api"
+	"github.com/dalyisaac/mstodo/datetime"
 	"github.com/dustin/go-humanize"
 	"github.com/iancoleman/strcase"
 	"github.com/jedib0t/go-pretty/v6/text"
@@ -42,7 +42,7 @@ var Transformer = text.Transformer(func(val interface{}) string {
 		return val
 	case time.Time:
 		return humanize.Time(val)
-	case *api.GraphTime:
+	case *datetime.GraphTime:
 		if val == nil {
 			return ""
 		}
@@ -68,7 +68,7 @@ var AbsoluteTimeTransformer = text.Transformer(func(val interface{}) string {
 	switch val := val.(type) {
 	case time.Time:
 		return val.Format(time.RFC1123)
-	case *api.GraphTime:
+	case *datetime.GraphTime:
 		if val == nil {
 			return ""
 		}

--- a/utils/transformers.go
+++ b/utils/transformers.go
@@ -17,7 +17,13 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 package utils
 
-import "github.com/jedib0t/go-pretty/v6/text"
+import (
+	"time"
+
+	"github.com/dalyisaac/mstodo/types"
+	"github.com/iancoleman/strcase"
+	"github.com/jedib0t/go-pretty/v6/text"
+)
 
 func boolToEmoji(v bool) string {
 	if v {
@@ -33,7 +39,23 @@ var Transformer = text.Transformer(func(val interface{}) string {
 		return boolToEmoji(val)
 	case string:
 		return val
+	case time.Time:
+		return types.ToRelativeTime(val)
+	case types.DateTimeTimeZone:
+		return val.String()
 	default:
 		return "unknown type"
 	}
+})
+
+var StatusTransformer = text.Transformer(func(val interface{}) string {
+	switch val := val.(type) {
+	case string:
+		val = strcase.ToDelimited(val, ' ')
+		if val == "completed" {
+			val = "✅"
+		}
+		return val
+	}
+	return "expected type string"
 })

--- a/utils/transformers.go
+++ b/utils/transformers.go
@@ -20,7 +20,7 @@ package utils
 import (
 	"time"
 
-	"github.com/dalyisaac/mstodo/types"
+	"github.com/dalyisaac/mstodo/api"
 	"github.com/iancoleman/strcase"
 	"github.com/jedib0t/go-pretty/v6/text"
 )
@@ -40,8 +40,8 @@ var Transformer = text.Transformer(func(val interface{}) string {
 	case string:
 		return val
 	case time.Time:
-		return types.ToRelativeTime(val)
-	case types.DateTimeTimeZone:
+		return api.ToRelativeTime(val)
+	case api.DateTimeTimeZone:
 		return val.String()
 	default:
 		return "unknown type"

--- a/utils/transformers.go
+++ b/utils/transformers.go
@@ -43,6 +43,11 @@ var Transformer = text.Transformer(func(val interface{}) string {
 		return api.ToRelativeTime(val)
 	case api.DateTimeTimeZone:
 		return val.String()
+	case *api.DateTimeTimeZone:
+		if val == nil {
+			return ""
+		}
+		return val.String()
 	default:
 		return "unknown type"
 	}

--- a/utils/transformers.go
+++ b/utils/transformers.go
@@ -42,13 +42,11 @@ var Transformer = text.Transformer(func(val interface{}) string {
 		return val
 	case time.Time:
 		return humanize.Time(val)
-	case api.DateTimeTimeZone:
-		return val.String()
-	case *api.DateTimeTimeZone:
+	case *api.GraphTime:
 		if val == nil {
 			return ""
 		}
-		return val.String()
+		return humanize.Time(time.Time(*val))
 	default:
 		return "unknown type"
 	}
@@ -64,4 +62,18 @@ var StatusTransformer = text.Transformer(func(val interface{}) string {
 		return val
 	}
 	return "expected type string"
+})
+
+var AbsoluteTimeTransformer = text.Transformer(func(val interface{}) string {
+	switch val := val.(type) {
+	case time.Time:
+		return val.Format(time.RFC1123)
+	case *api.GraphTime:
+		if val == nil {
+			return ""
+		}
+		return time.Time(*val).Format(time.RFC1123)
+	default:
+		return "unknown type"
+	}
 })

--- a/utils/transformers.go
+++ b/utils/transformers.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/dalyisaac/mstodo/api"
+	"github.com/dustin/go-humanize"
 	"github.com/iancoleman/strcase"
 	"github.com/jedib0t/go-pretty/v6/text"
 )
@@ -40,7 +41,7 @@ var Transformer = text.Transformer(func(val interface{}) string {
 	case string:
 		return val
 	case time.Time:
-		return api.ToRelativeTime(val)
+		return humanize.Time(val)
 	case api.DateTimeTimeZone:
 		return val.String()
 	case *api.DateTimeTimeZone:


### PR DESCRIPTION
feat: View task list items

Adds the ability to view the todo tasks of a Microsoft To Do list

Description:

```
View a specific task list.

Dates can be filtered using by specifying the start and/or end date you're interested in. For example:

--reminder="start Monday; end fri"

Usage:
  mstodo view <list name> [flags]

Flags:
  -a, --absolute               Show absolute datetime
  -o, --completed string       Filter by completed using the date syntax (default ".")
  -c, --created string         Filter by created using the date syntax (default ".")
  -d, --due string             Filter by due using the date syntax (default ".")
  -x, --exclude string         Exclude columns
  -h, --help                   help for view
  -i, --id                     Show the task IDs
  -m, --last-modified string   Filter by last-modified using the date syntax (default ".")
  -r, --reminder string        Filter by reminder using the date syntax (default ".")
  -s, --sort string            Sort by the fields, for example: --sort="[title:dsc,created:asc,status]" (default "none")
  -u, --status string          Filter the status (use 'completed' for ✅) (default ".")
  -l, --title string           Filter the task names which contain this regex (default ".")

Global Flags:
      --auth-timeout string   seconds to wait before giving up on authentication and exiting
      --config-dir string     config directory (default "/home/<USERNAME>/.mstodo")
      --port string           port for mstodo
  -t, --table-style string    the style for the table (default "Rounded")
```