### PR TITLE
ci: Added CI/CD releases and PR workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: Release mstodo
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  releases-matrix:
+    name: Release binary
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goos: [linux, darwin, windows]
+        goarch: [amd64]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: olegtarasov/get-tag@v2.1
+        id: tagName
+        with:
+          tagRegex: "v.*"
+      - uses: wangyoucao577/go-release-action@v1.18
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          goos: ${{ matrix.goos }}
+          goarch: ${{ matrix.goarch }}
+          ldflags: "-s -w -X 'github.com/dalyisaac/mstodo/build.Version=v1.0.0'"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,4 +23,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}
-          ldflags: "-s -w -X 'github.com/dalyisaac/mstodo/build.Version=v1.0.0'"
+          ldflags: "-s -w -X 'github.com/dalyisaac/mstodo/build.Version=${{ steps.tagName.outputs.tag }}'"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,13 +14,11 @@ jobs:
         goarch: [amd64]
     steps:
       - uses: actions/checkout@v2
-      - uses: olegtarasov/get-tag@v2.1
-        id: tagName
-        with:
-          tagRegex: "v.*"
+      - name: Set APP_VERSION env
+        run: echo APP_VERSION=$(echo ${GITHUB_REF} | rev | cut -d'/' -f 1 | rev ) >> ${GITHUB_ENV}
       - uses: wangyoucao577/go-release-action@v1.18
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}
-          ldflags: "-s -w -X 'github.com/dalyisaac/mstodo/build.Version=${{ steps.tagName.outputs.tag }}'"
+          ldflags: -s -w -X 'github.com/dalyisaac/mstodo/build.Version=${{env.APP_VERSION}}'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,24 @@
+name: Go
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+
+      - name: Build
+        run: go build -v ./...
+
+      - name: Test
+        run: go test -v ./...

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.exe
+mstodo

--- a/build/build.go
+++ b/build/build.go
@@ -1,0 +1,21 @@
+/*
+Copyright © 2021 Isaac Daly <isaac.daly@outlook.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package build
+
+// Application version
+var Version = "development"

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,39 @@
+/*
+Copyright © 2021 Isaac Daly <isaac.daly@outlook.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/dalyisaac/mstodo/build"
+	"github.com/spf13/cobra"
+)
+
+// versionCmd represents the version command
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "mstodo version",
+	Long:  `mstodo version`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("Version: " + build.Version)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}


### PR DESCRIPTION
- Creating a release via GitHub builds binaries for Windows, Linux, and macOS,
- Added workflow for PRs onto `main`

Closes #9 